### PR TITLE
Bash-autocomplete for unpin handles dashes in repo name.

### DIFF
--- a/xrepo-completion.bash
+++ b/xrepo-completion.bash
@@ -33,7 +33,7 @@ _xrepo()
         return 0
         ;;
       unpin)
-        local pinned_repos=$(xrepo pins | grep -v "pinned *" | grep -v "\-" | grep -v -e '^$')
+        local pinned_repos=$(xrepo pins | grep -v "pinned *" | grep -v "^\-" | grep -v -e '^$')
         COMPREPLY=($(compgen -W "${pinned_repos}" ${cur}))
         return 0
         ;;


### PR DESCRIPTION
The auto-complete for _xrepo unpin_ doesn't pick up repos with dashes in their name, such as _xrepo unpin MyService-Client_. I've made the grep expression slightly more specific, to exclude lines _beginning_ in a dash.
