### PR TITLE
GH-7: Fix error formatting in WhereCommand when assembly is not resolved

### DIFF
--- a/src/CommandLine/Commands/WhereCommand.cs
+++ b/src/CommandLine/Commands/WhereCommand.cs
@@ -13,7 +13,7 @@ namespace CommandLine.Commands
             var assemblyRegistration = Environment.AssemblyRegistry.GetAssembly(input.AssemblyName);
             if (assemblyRegistration == null)
             {
-                Console.WriteLine("Assembly '{0}' not registered. Have you ever built it on this machine?");
+                Console.WriteLine("Assembly '{0}' not registered. Have you ever built it on this machine?", input.AssemblyName);
                 return;
             }
 


### PR DESCRIPTION
Corrects the parameters to `Console.WriteLine` for formatting the error