### PR TITLE
Update where command to output project paths instead of package paths

### DIFF
--- a/src/CommandLine/Commands/Where.cs
+++ b/src/CommandLine/Commands/Where.cs
@@ -28,7 +28,7 @@ public class WhereCommand : Command
             var packageRegistration = environment.PackageRegistry.GetPackage(name)
                 ?? throw new CommandFailureException(12, $"No package with name '{name}' is registered. Have you ever built it on this machine?");
 
-            Console.Out.WriteList("packages", packageRegistration.Projects.OrderByDescending(p => p.Timestamp).Select(p => p.OutputPath));
+            Console.Out.WriteList("projects", packageRegistration.Projects.OrderByDescending(p => p.Timestamp).Select(p => p.ProjectPath));
         });
     }
 }

--- a/src/CommandLine/Commands/Where.cs
+++ b/src/CommandLine/Commands/Where.cs
@@ -28,7 +28,7 @@ public class WhereCommand : Command
             var packageRegistration = environment.PackageRegistry.GetPackage(name)
                 ?? throw new CommandFailureException(12, $"No package with name '{name}' is registered. Have you ever built it on this machine?");
 
-            Console.Out.WriteList("projects", packageRegistration.Projects.OrderByDescending(p => p.Timestamp).Select(p => p.ProjectPath));
+            Console.Out.WriteList("", packageRegistration.Projects.OrderByDescending(p => p.Timestamp).Select(p => p.ProjectPath));
         });
     }
 }


### PR DESCRIPTION
The where command was printing OutputPath (the nupkg path) for each
registered project. Changed it to print ProjectPath (the csproj path)
to match the which command's behavior.

https://claude.ai/code/session_01V3PnuN1BXFiVX5aiyXC8hT